### PR TITLE
Linux/SDL2: Correct IME candidate window position by sending caret re…

### DIFF
--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -248,6 +248,7 @@ void LLLineEditor::onFocusReceived()
     gEditMenuHandler = this;
     LLUICtrl::onFocusReceived();
     updateAllowingLanguageInput();
+    updateIMEWindowLocation(); // 追加
 }
 
 void LLLineEditor::onFocusLost()
@@ -514,6 +515,8 @@ void LLLineEditor::setCursor( S32 pos )
             mScrollHPos = getCursor();
         }
     }
+    // ここでキャレット/スクロール位置が確定
+    updateIMEWindowLocation(); // 追加
 }
 
 
@@ -829,6 +832,7 @@ BOOL LLLineEditor::handleMouseDown(S32 x, S32 y, MASK mask)
     if (mMouseDownSignal)
         (*mMouseDownSignal)(this,x,y,mask);
 
+    updateIMEWindowLocation(); // 追加
     return TRUE;
 }
 
@@ -908,6 +912,8 @@ BOOL LLLineEditor::handleHover(S32 x, S32 y, MASK mask)
         LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (active)" << LL_ENDL;
 #endif
         handled = TRUE;
+
+        updateIMEWindowLocation(); // 追加
     }
 
     if( !handled  )
@@ -955,6 +961,7 @@ BOOL LLLineEditor::handleMouseUp(S32 x, S32 y, MASK mask)
         // take selection to 'primary' clipboard
         updatePrimary();
     }
+    updateIMEWindowLocation(); // 追加
 
     // We won't call LLUICtrl::handleMouseUp to avoid double calls of  childrenHandleMouseUp().Just invoke the signal manually.
     if (mMouseUpSignal)
@@ -1686,6 +1693,7 @@ BOOL LLLineEditor::handleKeyHere(KEY key, MASK mask )
                 {
                     mSpellCheckTimer.setTimerExpirySec(SPELLCHECK_DELAY);
                 }
+                updateIMEWindowLocation(); // 追加
             }
         }
     }
@@ -1738,8 +1746,8 @@ BOOL LLLineEditor::handleUnicodeCharHere(llwchar uni_char)
             // HACK! The only usage of this callback doesn't do anything with the character.
             // We'll have to do something about this if something ever changes! - Doug
             onKeystroke();
-
             mSpellCheckTimer.setTimerExpirySec(SPELLCHECK_DELAY);
+            updateIMEWindowLocation(); // 追加
         }
     }
     return handled;
@@ -2153,13 +2161,16 @@ void LLLineEditor::draw()
                 }
 
                 // Make sure the IME is in the right place
-                S32 pixels_after_scroll = findPixelNearestPos();    // RCalculcate for IME position
-                LLRect screen_pos = calcScreenRect();
-                LLCoordGL ime_pos( screen_pos.mLeft + pixels_after_scroll, screen_pos.mTop - lineeditor_v_pad );
+                // S32 pixels_after_scroll = findPixelNearestPos();    // RCalculcate for IME position
+                // LLRect screen_pos = calcScreenRect();
+                // LLCoordGL ime_pos( screen_pos.mLeft + pixels_after_scroll, screen_pos.mTop - lineeditor_v_pad );
 
-                ime_pos.mX = (S32) (ime_pos.mX * LLUI::getScaleFactor().mV[VX]);
-                ime_pos.mY = (S32) (ime_pos.mY * LLUI::getScaleFactor().mV[VY]);
-                getWindow()->setLanguageTextInput( ime_pos );
+                // ime_pos.mX = (S32) (ime_pos.mX * LLUI::getScaleFactor().mV[VX]);
+                // ime_pos.mY = (S32) (ime_pos.mY * LLUI::getScaleFactor().mV[VY]);
+                // getWindow()->setLanguageTextInput( ime_pos );
+
+                // Make sure the IME is in the right place
+                updateIMEWindowLocation();
             }
         }
 
@@ -2786,4 +2797,52 @@ void LLLineEditor::setContextMenu(LLContextMenu* new_context_menu)
 void LLLineEditor::setFont(const LLFontGL* font)
 {
     mGLFont = font;
+}
+
+void LLLineEditor::updateIMEWindowLocation()
+{
+    LLWindow* window = getWindow();
+    if (!window || !hasFocus())
+    {
+        return;
+    }
+
+    // ユーザー微調整（論理px）
+    static LLUICachedControl<S32> kImeOffX("IMEOffsetX", 0);
+    static LLUICachedControl<S32> kImeOffY("IMEOffsetY", 0);
+
+    // 行高とベースライン付近の縦位置（draw() と同じ計算）
+    LLRect background(0, getRect().getHeight(), getRect().getWidth(), 0);
+    background.stretch(-mBorderThickness);
+    S32 lineeditor_v_pad = (background.getHeight() - mGLFont->getLineHeight()) / 2;
+    if (mSpellCheck) lineeditor_v_pad += 1;
+
+    // キャレットのローカルX（左上原点のローカル座標）
+    S32 caret_x_local = findPixelNearestPos();
+    S32 caret_y_local = lineeditor_v_pad; // ベースライン付近
+
+    // ローカル→スクリーン（top-left）
+    S32 sx = 0, sy = 0;
+    localPointToScreen(caret_x_local, caret_y_local, &sx, &sy);
+
+    // スクリーン→GL（bottom-left, 論理px）
+    LLCoordGL gl_pos;
+    LLUI::screenPointToGL(sx, sy, &gl_pos.mX, &gl_pos.mY);
+
+    // ユーザー微調整
+    gl_pos.mX += kImeOffX;
+    gl_pos.mY += kImeOffY;
+
+    // 矩形（LLRectはbottom-left原点）
+    const S32 caret_w = 16;
+    const S32 line_h  = ll_round((F32)mGLFont->getLineHeight());
+
+    LLRect ime_rect_gl;
+    ime_rect_gl.mLeft   = gl_pos.mX;
+    ime_rect_gl.mRight  = gl_pos.mX + caret_w;
+    ime_rect_gl.mBottom = gl_pos.mY;
+    ime_rect_gl.mTop    = gl_pos.mY + line_h;
+
+    // SDL2 / XIM とも下層で変換・反映する
+    window->setLanguageTextInputRect(ime_rect_gl);
 }

--- a/indra/llui/lllineeditor.h
+++ b/indra/llui/lllineeditor.h
@@ -297,6 +297,9 @@ public:
     typedef boost::function<void(S32&, S32&, LLWString&, S32&, const LLWString&)> autoreplace_callback_t;
     autoreplace_callback_t mAutoreplaceCallback;
     void            setAutoreplaceCallback(autoreplace_callback_t cb) { mAutoreplaceCallback = cb; }
+    // 追加: IME 候補ウィンドウ位置更新（ウィンドウ座標でキャレット矩形を通知）
+    void updateIMEWindowLocation();
+
 
   private:
     // private helper methods
@@ -336,7 +339,7 @@ public:
     void            setText(const LLStringExplicit &new_text, bool use_size_limit);
 
     void            setContextMenu(LLContextMenu* new_context_menu);
-
+    void            updateLanguageTextInputArea();
 
 protected:
     LLUIString      mText;                  // The string being edited.

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -652,13 +652,40 @@ void LLTextBase::drawCursor()
                     1);
             }
 
-            // Make sure the IME is in the right place
-            LLRect screen_pos = calcScreenRect();
-            LLCoordGL ime_pos( screen_pos.mLeft + llfloor(cursor_rect.mLeft), screen_pos.mBottom + llfloor(cursor_rect.mTop) );
+            // // Make sure the IME is in the right place
+            // LLRect screen_pos = calcScreenRect();
+            // LLCoordGL ime_pos( screen_pos.mLeft + llfloor(cursor_rect.mLeft), screen_pos.mBottom + llfloor(cursor_rect.mTop) );
 
-            ime_pos.mX = (S32) (ime_pos.mX * LLUI::getScaleFactor().mV[VX]);
-            ime_pos.mY = (S32) (ime_pos.mY * LLUI::getScaleFactor().mV[VY]);
-            getWindow()->setLanguageTextInput( ime_pos );
+            // ime_pos.mX = (S32) (ime_pos.mX * LLUI::getScaleFactor().mV[VX]);
+            // ime_pos.mY = (S32) (ime_pos.mY * LLUI::getScaleFactor().mV[VY]);
+            // getWindow()->setLanguageTextInput( ime_pos );
+
+            // Make sure the IME is in the right place (bottom-left origin, logical px)
+            static LLUICachedControl<S32> kImeOffX("IMEOffsetX", 0);
+            static LLUICachedControl<S32> kImeOffY("IMEOffsetY", 0);
+
+            // 1) ローカル → スクリーン（top-left）
+            S32 sx = 0, sy = 0;
+            localPointToScreen(llfloor(cursor_rect.mLeft), llfloor(cursor_rect.mBottom), &sx, &sy);
+
+            // 2) スクリーン → GL（bottom-left, 論理px）
+            LLCoordGL gl_pos;
+            LLUI::screenPointToGL(sx, sy, &gl_pos.mX, &gl_pos.mY);
+
+            // 3) オフセット適用
+            gl_pos.mX += kImeOffX;
+            gl_pos.mY += kImeOffY;
+
+            const S32 caret_w = 16;
+            const S32 line_h  = ll_round((F32)segmentp->getStyle()->getFont()->getLineHeight());
+
+            LLRect ime_rect_gl;
+            ime_rect_gl.mLeft   = gl_pos.mX;
+            ime_rect_gl.mRight  = gl_pos.mX + caret_w;
+            ime_rect_gl.mBottom = gl_pos.mY;
+            ime_rect_gl.mTop    = gl_pos.mY + line_h;
+
+            getWindow()->setLanguageTextInputRect(ime_rect_gl);
         }
     }
 }

--- a/indra/llwindow/llwindow.h
+++ b/indra/llwindow/llwindow.h
@@ -182,6 +182,7 @@ public:
     // control platform's Language Text Input mechanisms.
     virtual void allowLanguageTextInput(LLPreeditor *preeditor, BOOL b) {}
     virtual void setLanguageTextInput( const LLCoordGL & pos ) {};
+    virtual void setLanguageTextInputRect(const LLRect& r) {}
     virtual void updateLanguageTextInputArea() {}
     virtual void interruptLanguageTextInput() {}
     virtual void spawnWebBrowser(const std::string& escaped_url, bool async) {};

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -2429,6 +2429,42 @@ void LLWindowSDL::allowLanguageTextInput(LLPreeditor *preeditor, BOOL b)
     }
 }
 
+void LLWindowSDL::setLanguageTextInputRect(const LLRect& r_logical)
+{
+#if SDL_VERSION_ATLEAST(2,0,4)
+    if (!mWindow) return;
+
+    // HiDPIスケール（論理→実ピクセル）
+    int win_w=0, win_h=0, draw_w=0, draw_h=0;
+    SDL_GetWindowSize(mWindow, &win_w, &win_h);
+    SDL_GL_GetDrawableSize(mWindow, &draw_w, &draw_h);
+    const float sx = (win_w > 0) ? (float)draw_w / (float)win_w : 1.0f;
+    const float sy = (win_h > 0) ? (float)draw_h / (float)win_h : 1.0f;
+
+    // LLRect は bottom-left 原点。SDL は top-left 原点。
+    // ピクセルに変換
+    const int left_px   = llround((F32)r_logical.mLeft   * sx);
+    const int right_px  = llround((F32)r_logical.mRight  * sx);
+    const int bottom_px = llround((F32)r_logical.mBottom * sy);
+    const int top_px    = llround((F32)r_logical.mTop    * sy);
+
+    // 幅・高さ（ピクセル）
+    const int width_px  = llmax(0, right_px - left_px);
+    const int height_px = llmax(0, top_px - bottom_px);
+
+    // SDLのYは上原点なので、矩形の「上」を基準に反転
+    SDL_Rect rc;
+    rc.x = left_px;
+    rc.y = draw_h - top_px;   // 画面上からのオフセット
+    rc.w = width_px;
+    rc.h = height_px;
+
+    SDL_SetTextInputRect(&rc);
+#else
+    (void)r_logical;
+#endif
+}
+
 void LLWindowSDL::updateLanguageTextInputArea()
 {
     if (mLanguageTextInputAllowed && mPreeditor)
@@ -2450,25 +2486,40 @@ void LLWindowSDL::updateLanguageTextInputArea()
     }
 }
 
-void LLWindowSDL::setLanguageTextInput( const LLCoordGL & pos )
+void LLWindowSDL::setLanguageTextInput( const LLCoordGL & pos_logical )
 {
-    if (mLanguageTextInputAllowed && mPreeditor)
+#if SDL_VERSION_ATLEAST(2,0,4)
+    if (!mWindow || !mLanguageTextInputAllowed)
     {
-        LLCoordGL caret_coord;
-        LLRect preedit_bounds;
-        if (mPreeditor->getPreeditLocation(-1, &caret_coord, &preedit_bounds, NULL))
-        {
-            LLCoordWindow window_pos;
-            convertCoords(pos, &window_pos);
-
-            SDL_Rect coords;
-            coords.x = window_pos.mX;
-            coords.y = window_pos.mY;
-            coords.w = preedit_bounds.getWidth() - coords.x;
-            coords.h = preedit_bounds.getHeight() - coords.y;
-            SDL_SetTextInputRect(&coords);
-        }
+        return;
     }
+
+    // HiDPI スケール（論理→実ピクセル）
+    int win_w=0, win_h=0, draw_w=0, draw_h=0;
+    SDL_GetWindowSize(mWindow, &win_w, &win_h);
+    SDL_GL_GetDrawableSize(mWindow, &draw_w, &draw_h);
+    const float sx = (win_w > 0) ? (float)draw_w / (float)win_w : 1.0f;
+    const float sy = (win_h > 0) ? (float)draw_h / (float)win_h : 1.0f;
+
+    // bottom-left(論理) → 実ピクセル
+    const int px_x = llround((F32)pos_logical.mX * sx);
+    const int px_y = llround((F32)pos_logical.mY * sy);
+
+    // SDLは top-left 原点なので、Yを反転
+    // 矩形の高さは行高相当（固定でも可）
+    const int caret_h_px = 24;   // 必要なら調整
+    const int caret_w_px = 16;
+
+    SDL_Rect rc;
+    rc.x = px_x;
+    rc.y = draw_h - px_y - caret_h_px;  // 上原点に変換（高さ分オフセット）
+    rc.w = caret_w_px;
+    rc.h = caret_h_px;
+
+    SDL_SetTextInputRect(&rc);
+#else
+    (void)pos_logical;
+#endif
 }
 
 //static

--- a/indra/llwindow/llwindowsdl.h
+++ b/indra/llwindow/llwindowsdl.h
@@ -141,6 +141,7 @@ public:
     U32 getAvailableVRAMMegabytes() override;
 
     void allowLanguageTextInput(LLPreeditor *preeditor, BOOL b) override;
+    void setLanguageTextInputRect(const LLRect& r) override;
     void updateLanguageTextInputArea() override;
     void setLanguageTextInput( const LLCoordGL & pos ) override;
 
@@ -236,6 +237,9 @@ private:
 
     bool            mLanguageTextInputAllowed;
     LLPreeditor*    mPreeditor = nullptr;
+
+    SDL_Rect mIMERect{0,0,0,0};
+    float    mHiDPIScaleX = 1.0f, mHiDPIScaleY = 1.0f;
 };
 
 

--- a/indra/llwindow/llwindowwin32.h
+++ b/indra/llwindow/llwindowwin32.h
@@ -113,6 +113,7 @@ public:
     /*virtual*/ void focusClient();
 
     /*virtual*/ void allowLanguageTextInput(LLPreeditor *preeditor, BOOL b);
+    /*virtual*/ void setLanguageTextInputRect(const LLRect& /*r*/) override {}
     /*virtual*/ void setLanguageTextInput( const LLCoordGL & pos );
     /*virtual*/ void updateLanguageTextInputArea();
     /*virtual*/ void interruptLanguageTextInput();

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16448,5 +16448,20 @@
   <key>RenderShaderSalt</key>
   <map><key>Type</key><string>S32</string><key>Persist</key><integer>1</integer><key>Value</key><integer>0</integer></map>
 
+  <key>IMEOffsetX</key>
+  <map>
+    <key>Comment</key><string>IME candidate window X offset in logical pixels</string>
+    <key>Persist</key><integer>1</integer>
+    <key>Type</key><string>S32</string>
+    <key>Value</key><integer>0</integer>
+  </map>
+  <key>IMEOffsetY</key>
+  <map>
+    <key>Comment</key><string>IME candidate window Y offset in logical pixels (positive = up)</string>
+    <key>Persist</key><integer>1</integer>
+    <key>Type</key><string>S32</string>
+    <key>Value</key><integer>0</integer>
+  </map>
+
 </map>
 </llsd>


### PR DESCRIPTION
…ct via SDL_SetTextInputRect (local→screen→GL), drop legacy scaling, add IMEOffsetX/Y.